### PR TITLE
fix: FormSharePage navbar 설정

### DIFF
--- a/src/pages/FormShare.tsx
+++ b/src/pages/FormShare.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
 import FormEnter from '@/components/form/vote/FormEnter'
 import FormInfo from '@/components/form/vote/FormInfo'
 import SelectTrack from '@/components/form/vote/SelectTrack'
@@ -7,6 +7,8 @@ import FormEnd from '@/components/form/vote/FormEnd'
 import PageLayout from '@/components/shared/PageLayout'
 import { useGetFormData } from '@/hooks/useGetFormData'
 import { FormDataFromUser } from '@/models/form'
+import useNavbar from '@/hooks/useNavbar'
+import ShareLink from '@/components/form/share/ShareLink'
 
 export default function FormSharePage() {
   const [step, setStep] = useState<'시작' | '정보' | '투표' | '완료'>('시작')
@@ -17,6 +19,15 @@ export default function FormSharePage() {
   const { data: form } = useGetFormData(formId ?? '') as {
     data: FormDataFromUser
   }
+
+  const { updateNavbar } = useNavbar()
+
+  useEffect(() => {
+    updateNavbar({
+      left: <Link to={`/myforms`}>My forms</Link>,
+      right: <ShareLink />,
+    })
+  }, [updateNavbar])
 
   return (
     <PageLayout>


### PR DESCRIPTION
## 작업 내용
#33
- [x] merge conflict 해결 과정에서 FormSharePage의 navbar 구현 내용이 없어져 이를 다시 설정
