### PR TITLE
fix: voteData가 0일 경우 퍼센트가 NaN으로 나타나는 문제 해결

### DIFF
--- a/src/components/form/result/ResultDetail.tsx
+++ b/src/components/form/result/ResultDetail.tsx
@@ -41,13 +41,20 @@ export default function ResultDetail({ album, voteCount }: ResultDetailProps) {
       <ul>
         {tracks.map((track, index) => {
           const trackVoteCount = trackCounts[track.track_number] || 0
-          let trackPercentage = (trackVoteCount / voteCount) * 100
+          let trackPercentage
+          if (trackVoteCount === 0) {
+            trackPercentage = 0
+          } else {
+            trackPercentage = (trackVoteCount / voteCount) * 100
+          }
           if (Number.isInteger(trackPercentage)) {
             trackPercentage = Math.round(trackPercentage)
           } else {
             trackPercentage = parseFloat(trackPercentage.toFixed(1))
           }
+
           const color = getRandomColor(index)
+
           return (
             <li key={track.id}>
               <div css={listInfoStyles}>


### PR DESCRIPTION
## 작업 내용
#34 
- [x] voteData가 0일 경우 퍼센트가 NaN으로 나타나는 문제 해결

## 스크린샷
**문제 상황**
![image](https://github.com/uussong/go-to-track/assets/77879633/255ff0d6-2800-40c6-a2ca-3d35c3780df2)

**해결**
![image](https://github.com/uussong/go-to-track/assets/77879633/a4dd278a-93bb-46d6-b44c-dc1b429f637c)
