### PR TITLE
Design: FormCreate 관련 페이지 UI 개선

### DIFF
--- a/src/components/form/content/AlbumList.tsx
+++ b/src/components/form/content/AlbumList.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react'
 import { AlbumData } from '@/models/album'
 import { Skeleton } from '../../shared/skeleton'
 import { Text } from '../../shared/text'
+import { colors } from '@/styles/colors'
 
 interface AlbumListProps {
   data: AlbumData[]
@@ -13,7 +14,7 @@ export default function AlbumList({ data, onNext }: AlbumListProps) {
   const [isLoading, setIsLoading] = useState(true)
 
   return (
-    <section css={sectionStyles}>
+    <div css={articleWrapperStyles}>
       {data.map((album: AlbumData) => (
         <article
           css={articleStyles}
@@ -29,18 +30,21 @@ export default function AlbumList({ data, onNext }: AlbumListProps) {
             alt={album.name}
             onLoad={() => setIsLoading(false)}
           />
-          <Text css={{ textAlign: 'center' }}>{album.name}</Text>
+          <Text css={albumNameStyles} variant={'heading3'}>
+            {album.name}
+          </Text>
         </article>
       ))}
-    </section>
+    </div>
   )
 }
 
-const sectionStyles = css`
+const articleWrapperStyles = css`
   display: grid;
   grid-template-columns: 1fr 1fr;
   justify-items: center;
-  gap: 13px;
+  gap: 10px 13px;
+  padding: 25px 0;
 `
 
 const articleStyles = css`
@@ -48,9 +52,20 @@ const articleStyles = css`
   flex-direction: column;
   align-items: center;
   width: 165px;
+  padding: 20px 10px;
+  background-color: ${colors.gray100};
+  border-radius: 10px;
+  cursor: pointer;
 `
 
 const imgStyles = (isLoading: boolean) => css`
   display: ${isLoading ? `none` : `block`};
-  width: 125px;
+  width: 100px;
+  border-radius: 4px;
+`
+
+const albumNameStyles = css`
+  font-size: 16px;
+  padding-top: 10px;
+  text-align: center;
 `

--- a/src/components/form/content/ArtistInfo.tsx
+++ b/src/components/form/content/ArtistInfo.tsx
@@ -20,7 +20,7 @@ export default function ArtistInfo({ data }: ArtistInfoProps) {
         alt={data[0].name}
         onLoad={() => setIsLoading(false)}
       />
-      <Text variant={'heading2'}>{data[0].name}</Text>
+      <Text variant={'heading3'}>{data[0].name}</Text>
     </article>
   )
 }

--- a/src/components/form/content/ConfirmTrack.tsx
+++ b/src/components/form/content/ConfirmTrack.tsx
@@ -19,21 +19,25 @@ export default function ConfirmTrack({
   const { data } = useGetTracks(albumId)
 
   return (
-    <>
+    <section css={sectionStyles}>
       <Text variant={'heading2'}>수록곡 목록을 확인해주세요</Text>
       <TrackList data={data} />
       <div css={buttonGroupStyles}>
         <Button variant={'secondary'} onClick={onPrevious}>
-          이전
+          앨범 다시 선택하기
         </Button>
         <CompleteButton onComplete={onComplete} />
       </div>
-    </>
+    </section>
   )
 }
+
+const sectionStyles = css`
+  padding-top: 50px;
+`
 
 const buttonGroupStyles = css`
   display: flex;
   justify-content: flex-end;
-  gap: 5px;
+  gap: 10px;
 `

--- a/src/components/form/content/SearchArtist.tsx
+++ b/src/components/form/content/SearchArtist.tsx
@@ -5,7 +5,8 @@ import { useSearchArtist } from '@/hooks/useSearchArtist'
 import ArtistInfo from './ArtistInfo'
 import { Button } from '../../shared/button'
 import { Text } from '../../shared/text'
-import { flexColumn } from '@/styles/mixins'
+import { flexColumnCenter } from '@/styles/mixins'
+import { TextInput } from '@/components/shared/textInput'
 
 interface SearchArtistProps {
   onNext: (artistId: string) => void
@@ -28,17 +29,17 @@ export default function SearchArtist({ onNext }: SearchArtistProps) {
     <>
       <section css={inputSectionStyles}>
         <Text variant={'heading2'}>원하는 가수를 검색해보세요</Text>
-        <form onSubmit={handleSubmit}>
-          <input type="text" value={searchInput} onChange={handleInput} />
+        <form css={formStyles} onSubmit={handleSubmit}>
+          <TextInput label={'가수 검색'} onChange={handleInput} />
         </form>
       </section>
       <section css={resultSectionStyles}>
         {isLoading || data === undefined ? null : data.length === 0 ? (
-          <Text>찾는 가수가 없어요</Text>
+          <Text>원하는 가수가 없어요</Text>
         ) : (
           <>
             <ArtistInfo data={data} />
-            <Text variant={'bodyStrong'}>찾는 가수가 맞나요?</Text>
+            <Text>원하는 가수가 맞나요?</Text>
             <Button
               onClick={() => {
                 onNext(data[0].id)
@@ -54,12 +55,16 @@ export default function SearchArtist({ onNext }: SearchArtistProps) {
 }
 
 const inputSectionStyles = css`
-  padding-bottom: 25px;
+  padding: 50px 0 25px;
+`
+
+const formStyles = css`
+  padding-top: 20px;
 `
 
 const resultSectionStyles = css`
-  ${flexColumn}
+  ${flexColumnCenter}
+  flex: 1;
   align-items: center;
   gap: 25px;
-  padding-top: 25px;
 `

--- a/src/components/form/content/SelectAlbum.tsx
+++ b/src/components/form/content/SelectAlbum.tsx
@@ -18,22 +18,18 @@ export default function SelectAlbum({
   const { data } = useGetAlbums(artistId)
 
   return (
-    <>
+    <section css={sectionStyles}>
+      <Text variant={'heading2'}>수록곡 투표를 만들 앨범을 선택해주세요</Text>
+      <AlbumList data={data} onNext={onNext} />
       {onPrevious && (
         <Button variant={'secondary'} onClick={onPrevious}>
-          이전
+          가수 다시 검색하기
         </Button>
       )}
-      <Text css={titleStyles} variant={'heading2'}>
-        수록곡을 투표 할 앨범을 선택해주세요
-      </Text>
-
-      <AlbumList data={data} onNext={onNext} />
-    </>
+    </section>
   )
 }
 
-const titleStyles = css`
-  padding-bottom: 25px;
-  text-align: center;
+const sectionStyles = css`
+  padding-top: 50px;
 `

--- a/src/components/form/content/TrackList.tsx
+++ b/src/components/form/content/TrackList.tsx
@@ -23,7 +23,7 @@ const listStyles = css`
   display: flex;
   flex-direction: column;
   gap: 5px;
-  margin: 10px 0;
+  padding: 25px 0;
 `
 
 const listItemStyles = css`

--- a/src/components/form/title/EnterTitle.tsx
+++ b/src/components/form/title/EnterTitle.tsx
@@ -1,7 +1,9 @@
 import { ChangeEvent, FormEvent, useState } from 'react'
+import { css } from '@emotion/react'
 import { Button } from '../../shared/button'
 import { Text } from '../../shared/text'
 import { useNavigate } from 'react-router-dom'
+import { TextInput } from '@/components/shared/textInput'
 
 interface EnterTitleProps {
   setFormTitle: (formTitle: string) => void
@@ -22,15 +24,27 @@ export default function EnterTitle({ setFormTitle }: EnterTitleProps) {
   }
 
   return (
-    <>
-      <Text>수록곡 설문을 만들러 가봅시다</Text>
-      <Text variant={'heading2'}>먼저 제목을 입력해주세요</Text>
-      <form onSubmit={handleSubmit}>
-        <input type="text" value={input} onChange={handleInput} />
-        <Button type={'submit'} disabled={input === ''}>
+    <section css={sectionStyles}>
+      <Text variant={'heading2'}>투표 제목을 입력해주세요</Text>
+      <form css={formStyles} onSubmit={handleSubmit}>
+        <TextInput label={'투표 폼 제목'} onChange={handleInput} />
+        <Button css={buttonStyles} type={'submit'} disabled={input === ''}>
           계속
         </Button>
       </form>
-    </>
+    </section>
   )
 }
+
+const sectionStyles = css`
+  padding-top: 50px;
+`
+
+const formStyles = css`
+  margin-top: 16px;
+`
+
+const buttonStyles = css`
+  margin-top: 16px;
+  float: right;
+`


### PR DESCRIPTION
## 작업 내용
#42 FormTitleCreate, FormContentCreate 페이지 UI 개선: page layout 조정, TextInput 등 공통 컴포넌트 적용, 카드 ui 스타일링 등
- [x]  EnterTitle 관련 UI 개선
- [x]  SearchArtist 관련 UI 개선
- [x]  SelectAlbum 관련 UI 개선
- [x]  ConfirmTrack 관련 UI 개선

## 스크린샷
<img width="278" alt="image" src="https://github.com/uussong/go-to-track/assets/77879633/faf29904-b2d9-48c4-b1d4-5d14f5e64c9e">
<img width="281" alt="image" src="https://github.com/uussong/go-to-track/assets/77879633/70429b86-9c97-48da-865a-815dbb07640b">
<img width="278" alt="image" src="https://github.com/uussong/go-to-track/assets/77879633/23360580-14de-4b4e-b83e-ffa3cccf29be">
