### PR TITLE
feat: 무한 스크롤 구현

### DIFF
--- a/src/components/home/AllFormList.tsx
+++ b/src/components/home/AllFormList.tsx
@@ -16,7 +16,9 @@ export default function AllFormList({
 }: AllFormListProps) {
   return (
     <section css={sectionStyles}>
-      <Text variant={'heading2'}>지금 바로 최애곡을 뽑아보세요</Text>
+      <Text variant={'heading2'} css={headingStyles}>
+        지금 바로 최애곡을 뽑아보세요
+      </Text>
       {formList.map((form) => (
         <Suspense
           key={form.id}
@@ -33,4 +35,8 @@ export default function AllFormList({
 const sectionStyles = css`
   width: 100%;
   padding-top: 50px;
+`
+
+const headingStyles = css`
+  margin-bottom: 16px;
 `

--- a/src/components/home/AllFormList.tsx
+++ b/src/components/home/AllFormList.tsx
@@ -18,8 +18,11 @@ export default function AllFormList({
     <section css={sectionStyles}>
       <Text variant={'heading2'}>지금 바로 최애곡을 뽑아보세요</Text>
       {formList.map((form) => (
-        <Suspense fallback={<Skeleton height={162} margin={10} />}>
-          <FormItem key={form.id} form={form} />
+        <Suspense
+          key={form.id}
+          fallback={<Skeleton height={162} margin={10} />}
+        >
+          <FormItem form={form} />
         </Suspense>
       ))}
       <div ref={lastFormRef}></div>

--- a/src/components/home/AllFormList.tsx
+++ b/src/components/home/AllFormList.tsx
@@ -1,7 +1,7 @@
+import { css } from '@emotion/react'
 import { FormListData } from '@/models/form'
 import { Text } from '../shared/text'
 import FormItem from './FormItem'
-import { css } from '@emotion/react'
 
 interface AllFormListProps {
   formList: FormListData[]

--- a/src/components/home/AllFormList.tsx
+++ b/src/components/home/AllFormList.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react'
+import { RefObject, Suspense } from 'react'
 import { css } from '@emotion/react'
 import { FormListData } from '@/models/form'
 import { Text } from '../shared/text'
@@ -7,9 +7,13 @@ import { Skeleton } from '../shared/skeleton'
 
 interface AllFormListProps {
   formList: FormListData[]
+  lastFormRef: RefObject<HTMLDivElement>
 }
 
-export default function AllFormList({ formList }: AllFormListProps) {
+export default function AllFormList({
+  formList,
+  lastFormRef,
+}: AllFormListProps) {
   return (
     <section css={sectionStyles}>
       <Text variant={'heading2'}>지금 바로 최애곡을 뽑아보세요</Text>
@@ -18,6 +22,7 @@ export default function AllFormList({ formList }: AllFormListProps) {
           <FormItem key={form.id} form={form} />
         </Suspense>
       ))}
+      <div ref={lastFormRef}></div>
     </section>
   )
 }

--- a/src/components/home/AllFormList.tsx
+++ b/src/components/home/AllFormList.tsx
@@ -1,7 +1,9 @@
+import { Suspense } from 'react'
 import { css } from '@emotion/react'
 import { FormListData } from '@/models/form'
 import { Text } from '../shared/text'
 import FormItem from './FormItem'
+import { Skeleton } from '../shared/skeleton'
 
 interface AllFormListProps {
   formList: FormListData[]
@@ -12,7 +14,9 @@ export default function AllFormList({ formList }: AllFormListProps) {
     <section css={sectionStyles}>
       <Text variant={'heading2'}>지금 바로 최애곡을 뽑아보세요</Text>
       {formList.map((form) => (
-        <FormItem key={form.id} form={form} />
+        <Suspense fallback={<Skeleton height={162} margin={10} />}>
+          <FormItem key={form.id} form={form} />
+        </Suspense>
       ))}
     </section>
   )

--- a/src/components/home/AllFormList.tsx
+++ b/src/components/home/AllFormList.tsx
@@ -20,7 +20,7 @@ export default function AllFormList({
       {formList.map((form) => (
         <Suspense
           key={form.id}
-          fallback={<Skeleton height={162} margin={10} />}
+          fallback={<Skeleton height={160} borderRadius={4} margin={10} />}
         >
           <FormItem form={form} />
         </Suspense>

--- a/src/components/home/FormItem.tsx
+++ b/src/components/home/FormItem.tsx
@@ -15,7 +15,7 @@ export default function FormItem({ form }: FormItemProps) {
   const { data: count } = useGetVoteCount(form.id)
   const { data: artist } = useGetArtistInfo(form.data.artistId)
   const { data: album } = useGetAlbumInfo(form.data.albumId)
-  console.log(album)
+
   return (
     <article>
       <Link to={`/vote/${form.id}`}>

--- a/src/components/shared/skeleton/index.tsx
+++ b/src/components/shared/skeleton/index.tsx
@@ -2,20 +2,27 @@ import { colors } from '@/styles/colors'
 import { css, keyframes } from '@emotion/react'
 
 interface SkeletonProps {
-  width: number
+  width?: number
   height: number
   borderRadius?: number
+  margin?: number
 }
 
-export function Skeleton({ width, height, borderRadius }: SkeletonProps) {
+export function Skeleton({
+  width,
+  height,
+  borderRadius,
+  margin,
+}: SkeletonProps) {
   return (
     <div
       css={[
         skeletonStyles,
         css`
-          width: ${width}px;
+          width: ${`width ? ${width}px : 100%`};
           height: ${height}px;
           border-radius: ${borderRadius}px;
+          margin: ${margin}px;
         `,
       ]}
     ></div>

--- a/src/components/shared/skeleton/index.tsx
+++ b/src/components/shared/skeleton/index.tsx
@@ -46,7 +46,7 @@ const loading = keyframes`
 const skeletonStyles = css`
   position: relative;
   overflow: hidden;
-  background: ${colors.gray200};
+  background: ${colors.gray100};
 
   &::after {
     position: absolute;
@@ -59,7 +59,7 @@ const skeletonStyles = css`
     background: linear-gradient(
       90deg,
       transparent,
-      ${colors.gray100},
+      ${colors.white},
       transparent
     );
   }

--- a/src/hooks/useGetAllFormData.tsx
+++ b/src/hooks/useGetAllFormData.tsx
@@ -1,9 +1,0 @@
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { getAllFormData } from '@/remote/form'
-
-export const useGetAllFormData = () => {
-  return useSuspenseQuery({
-    queryKey: ['allFormData'],
-    queryFn: () => getAllFormData(),
-  })
-}

--- a/src/hooks/usePaginatedFormData.tsx
+++ b/src/hooks/usePaginatedFormData.tsx
@@ -1,10 +1,15 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { fetchInitialFormList, fetchNextFormList } from '@/remote/form'
+import { DocumentData, DocumentSnapshot } from 'firebase/firestore'
 
 export const usePaginatedFormData = () => {
   return useInfiniteQuery({
     queryKey: ['paginatedFormData'],
-    queryFn: ({ pageParam }: { pageParam: any }) => {
+    queryFn: ({
+      pageParam,
+    }: {
+      pageParam: DocumentSnapshot<DocumentData> | null
+    }) => {
       return pageParam ? fetchNextFormList(pageParam) : fetchInitialFormList()
     },
     getNextPageParam: (lastPage) => lastPage.lastVisible,

--- a/src/hooks/usePaginatedFormData.tsx
+++ b/src/hooks/usePaginatedFormData.tsx
@@ -1,0 +1,13 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { fetchInitialFormList, fetchNextFormList } from '@/remote/form'
+
+export const usePaginatedFormData = () => {
+  return useInfiniteQuery({
+    queryKey: ['paginatedFormData'],
+    queryFn: ({ pageParam }: { pageParam: any }) => {
+      return pageParam ? fetchNextFormList(pageParam) : fetchInitialFormList()
+    },
+    getNextPageParam: (lastPage) => lastPage.lastVisible,
+    initialPageParam: null,
+  })
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import PageLayout from '@/components/shared/PageLayout'
 import useNavbar from '@/hooks/useNavbar'
 import SignOut from '@/components/shared/SignOut'
-import { useGetAllFormData } from '@/hooks/useGetAllFormData'
+import { usePaginatedFormData } from '@/hooks/usePaginatedFormData'
 import AllFormList from '@/components/home/AllFormList'
 import Introduction from '@/components/home/Introduction'
 import { Text } from '@/components/shared/text'
@@ -12,7 +12,9 @@ import { useUser } from '@/hooks/useUser'
 export default function HomePage() {
   const { updateNavbar } = useNavbar()
   const user = useUser()
-  const { data: formList } = useGetAllFormData()
+  const { data } = usePaginatedFormData()
+
+  const formList = data?.pages.flatMap((forms) => forms.formList)
 
   useEffect(() => {
     updateNavbar({
@@ -28,7 +30,7 @@ export default function HomePage() {
   return (
     <PageLayout>
       <Introduction />
-      <AllFormList formList={formList} />
+      {formList && <AllFormList formList={formList} />}
     </PageLayout>
   )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,11 +8,12 @@ import AllFormList from '@/components/home/AllFormList'
 import Introduction from '@/components/home/Introduction'
 import { Text } from '@/components/shared/text'
 import { useUser } from '@/hooks/useUser'
+import { Button } from '@/components/shared/button'
 
 export default function HomePage() {
   const { updateNavbar } = useNavbar()
   const user = useUser()
-  const { data } = usePaginatedFormData()
+  const { data, fetchNextPage } = usePaginatedFormData()
 
   const formList = data?.pages.flatMap((forms) => forms.formList)
 
@@ -31,6 +32,9 @@ export default function HomePage() {
     <PageLayout>
       <Introduction />
       {formList && <AllFormList formList={formList} />}
+      <Button variant={'secondary'} onClick={() => fetchNextPage()}>
+        불러오기
+      </Button>
     </PageLayout>
   )
 }

--- a/src/remote/form.ts
+++ b/src/remote/form.ts
@@ -10,6 +10,8 @@ import {
   deleteDoc,
   setDoc,
   where,
+  startAfter,
+  limit,
 } from 'firebase/firestore'
 import { store } from './firebase'
 import {
@@ -34,12 +36,14 @@ export const saveFormData = async (user: User, formData: FormDataFromUser) => {
   await addDoc(formDataRef, formDataToSave)
 }
 
-export const getAllFormData = async () => {
-  const formRef = collection(store, COLLECTIONS.FORM)
-
-  const querySnapshot = await getDocs(formRef)
-
-  const formList: FormListData[] = querySnapshot.docs.map((doc) => {
+export const fetchInitialFormList = async () => {
+  const firstQuery = query(
+    collection(store, COLLECTIONS.FORM),
+    orderBy('timestamp'),
+    limit(2),
+  )
+  const firstSnapshot = await getDocs(firstQuery)
+  const formList: FormListData[] = firstSnapshot.docs.map((doc) => {
     const formData = doc.data()
     return {
       id: doc.id,
@@ -47,13 +51,41 @@ export const getAllFormData = async () => {
         albumId: formData.albumId,
         artistId: formData.artistId,
         formTitle: formData.formTitle,
-        uid: formData.uid,
         timestamp: formData.timestamp.toDate(),
       },
     }
   })
 
-  return formList
+  return {
+    formList,
+    lastVisible: firstSnapshot.docs[firstSnapshot.docs.length - 1],
+  }
+}
+
+export const fetchNextFormList = async (lastVisible: any) => {
+  const nextQuery = query(
+    collection(store, COLLECTIONS.FORM),
+    orderBy('timestamp'),
+    startAfter(lastVisible),
+    limit(2),
+  )
+  const nextSnapshot = await getDocs(nextQuery)
+  const formList: FormListData[] = nextSnapshot.docs.map((doc) => {
+    const formData = doc.data()
+    return {
+      id: doc.id,
+      data: {
+        albumId: formData.albumId,
+        artistId: formData.artistId,
+        formTitle: formData.formTitle,
+        timestamp: formData.timestamp.toDate(),
+      },
+    }
+  })
+  return {
+    formList,
+    lastVisible: nextSnapshot.docs[nextSnapshot.docs.length - 1],
+  }
 }
 
 export const getUserFormList = async (user: User) => {

--- a/src/remote/form.ts
+++ b/src/remote/form.ts
@@ -41,8 +41,8 @@ export const saveFormData = async (user: User, formData: FormDataFromUser) => {
 export const fetchInitialFormList = async () => {
   const firstQuery = query(
     collection(store, COLLECTIONS.FORM),
-    orderBy('timestamp'),
-    limit(2),
+    orderBy('timestamp', 'desc'),
+    limit(5),
   )
   const firstSnapshot = await getDocs(firstQuery)
   const formList: FormListData[] = firstSnapshot.docs.map((doc) => {
@@ -69,9 +69,9 @@ export const fetchNextFormList = async (
 ) => {
   const nextQuery = query(
     collection(store, COLLECTIONS.FORM),
-    orderBy('timestamp'),
+    orderBy('timestamp', 'desc'),
     startAfter(lastVisible),
-    limit(2),
+    limit(5),
   )
   const nextSnapshot = await getDocs(nextQuery)
   const formList: FormListData[] = nextSnapshot.docs.map((doc) => {

--- a/src/remote/form.ts
+++ b/src/remote/form.ts
@@ -10,8 +10,10 @@ import {
   deleteDoc,
   setDoc,
   where,
+  DocumentSnapshot,
   startAfter,
   limit,
+  DocumentData,
 } from 'firebase/firestore'
 import { store } from './firebase'
 import {
@@ -62,7 +64,9 @@ export const fetchInitialFormList = async () => {
   }
 }
 
-export const fetchNextFormList = async (lastVisible: any) => {
+export const fetchNextFormList = async (
+  lastVisible: DocumentSnapshot<DocumentData>,
+) => {
   const nextQuery = query(
     collection(store, COLLECTIONS.FORM),
     orderBy('timestamp'),


### PR DESCRIPTION
## 작업 내용
#47 Home 페이지의 폼 목록에 무한 스크롤 기능 추가
- [x] 전체 폼 목록 불러오는 함수를 수정해 페이지네이션 지원하도록 구현
- [x] 무한 스크롤 구현
- [x] 스켈레톤 UI 일부 수정

## 스크린샷
![ezgif-6-6888376c48](https://github.com/uussong/go-to-track/assets/77879633/038bf75e-0636-4d85-beb2-019019acf71f)
