### PR TITLE
feat: 이미지 로딩 시 스켈레톤 UI 적용

### DIFF
--- a/src/components/form/FormDetail.tsx
+++ b/src/components/form/FormDetail.tsx
@@ -9,6 +9,7 @@ import { colors } from '@/styles/colors'
 import { useUpdateFormData } from '@/hooks/useUpdateFormData'
 import { flexCenter } from '@/styles/mixins'
 import { useNavigate, useParams } from 'react-router-dom'
+import { Skeleton } from '../shared/skeleton'
 
 interface formDetailProps {
   form: FormDataFromServer
@@ -19,6 +20,10 @@ interface formDetailProps {
 export default function FormDetail({ form, artist, album }: formDetailProps) {
   const [title, setTitle] = useState('')
   const [isTrackListVisible, setIsTrackListVisible] = useState(false)
+  const [isLoading, setIsLoading] = useState({
+    artistImageLoading: true,
+    albumImageLoading: true,
+  })
   const tracks = album.tracks.items
   const { mutate } = useUpdateFormData()
   const navigate = useNavigate()
@@ -72,7 +77,22 @@ export default function FormDetail({ form, artist, album }: formDetailProps) {
       </Text>
       <article css={articleStyles}>
         <div css={infoArticleStyles}>
-          <img css={imageStyles} src={artist.images[2].url} alt={artist.name} />
+          <div css={imageWrapperStyles}>
+            {isLoading.artistImageLoading && (
+              <Skeleton width={75} height={75} borderRadius={10} />
+            )}
+            <img
+              css={imageStyles(isLoading.artistImageLoading)}
+              src={artist.images[2].url}
+              alt={artist.name}
+              onLoad={() =>
+                setIsLoading((prevState) => ({
+                  ...prevState,
+                  artistImageLoading: false,
+                }))
+              }
+            />
+          </div>
           <Text variant={'bodyStrong'}>{artist.name}</Text>
         </div>
         <Button
@@ -86,7 +106,22 @@ export default function FormDetail({ form, artist, album }: formDetailProps) {
       <div css={lineStyles}></div>
       <article css={articleStyles}>
         <div css={infoArticleStyles}>
-          <img css={imageStyles} src={album.images[1].url} alt={album.name} />
+          <div css={imageWrapperStyles}>
+            {isLoading.albumImageLoading && (
+              <Skeleton width={75} height={75} borderRadius={10} />
+            )}
+            <img
+              css={imageStyles(isLoading.albumImageLoading)}
+              src={album.images[1].url}
+              alt={album.name}
+              onLoad={() =>
+                setIsLoading((prevState) => ({
+                  ...prevState,
+                  albumImageLoading: false,
+                }))
+              }
+            />
+          </div>
           <div css={albumDetailStyles}>
             <Text variant={'bodyStrong'}>{album.name}</Text>
             <Button variant={'primary'} onClick={toggleTrackListVisible}>
@@ -134,9 +169,16 @@ const lineStyles = css`
   border: 1px solid ${colors.gray100};
 `
 
-const imageStyles = css`
+const imageWrapperStyles = css`
   width: 75px;
   height: 75px;
+`
+
+const imageStyles = (isLoading: boolean) => css`
+  display: ${isLoading ? `none` : `block`};
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   border-radius: 10px;
 `
 

--- a/src/components/form/content/AlbumList.tsx
+++ b/src/components/form/content/AlbumList.tsx
@@ -23,13 +23,15 @@ export default function AlbumList({ data, onNext }: AlbumListProps) {
             onNext(album.id)
           }}
         >
-          {isLoading && <Skeleton width={125} height={125} />}
-          <img
-            css={imgStyles(isLoading)}
-            src={album.images[1].url}
-            alt={album.name}
-            onLoad={() => setIsLoading(false)}
-          />
+          <div css={imgWrapperStyles}>
+            {isLoading && <Skeleton width={100} height={100} />}
+            <img
+              css={imgStyles(isLoading)}
+              src={album.images[1].url}
+              alt={album.name}
+              onLoad={() => setIsLoading(false)}
+            />
+          </div>
           <Text css={albumNameStyles} variant={'heading3'}>
             {album.name}
           </Text>
@@ -58,9 +60,16 @@ const articleStyles = css`
   cursor: pointer;
 `
 
+const imgWrapperStyles = css`
+  width: 100px;
+  height: 100px;
+`
+
 const imgStyles = (isLoading: boolean) => css`
   display: ${isLoading ? `none` : `block`};
-  width: 100px;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   border-radius: 4px;
 `
 

--- a/src/components/form/content/ArtistInfo.tsx
+++ b/src/components/form/content/ArtistInfo.tsx
@@ -13,13 +13,15 @@ export default function ArtistInfo({ data }: ArtistInfoProps) {
 
   return (
     <article css={articleStyles}>
-      {isLoading && <Skeleton width={200} height={200} borderRadius={200} />}
-      <img
-        css={imgStyles(isLoading)}
-        src={data[0].images[1].url}
-        alt={data[0].name}
-        onLoad={() => setIsLoading(false)}
-      />
+      <div css={imgWrapperStyles}>
+        {isLoading && <Skeleton width={300} height={300} borderRadius={300} />}
+        <img
+          css={imgStyles(isLoading)}
+          src={data[0].images[1].url}
+          alt={data[0].name}
+          onLoad={() => setIsLoading(false)}
+        />
+      </div>
       <Text variant={'heading3'}>{data[0].name}</Text>
     </article>
   )
@@ -29,13 +31,18 @@ const articleStyles = css`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 25px;
+`
+
+const imgWrapperStyles = css`
+  width: 300px;
+  height: 300px;
 `
 
 const imgStyles = (isLoading: boolean) => css`
   display: ${isLoading ? `none` : `block`};
-  width: 200px;
-  height: 200px;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   object-fit: cover;
 `

--- a/src/components/form/vote/FormInfo.tsx
+++ b/src/components/form/vote/FormInfo.tsx
@@ -5,6 +5,8 @@ import { useGetAlbumInfo } from '@/hooks/useGetAlbumInfo'
 import { useGetArtistInfo } from '@/hooks/useGetArtistInfo'
 import { FormDataFromUser } from '@/models/form'
 import { flexColumnCenter } from '@/styles/mixins'
+import { useState } from 'react'
+import { Skeleton } from '@/components/shared/skeleton'
 
 interface FormInfoProps {
   form: FormDataFromUser
@@ -12,6 +14,7 @@ interface FormInfoProps {
 }
 
 export default function FormInfo({ form, onNext }: FormInfoProps) {
+  const [isLoading, setIsLoading] = useState(true)
   const { data: artist } = useGetArtistInfo(form.artistId)
   const { data: album } = useGetAlbumInfo(form.albumId)
 
@@ -23,7 +26,13 @@ export default function FormInfo({ form, onNext }: FormInfoProps) {
           {album.name}
         </Text>
         <div css={imageWrapperStyles}>
-          <img css={imageStyles} src={album.images[1].url} alt={album.name} />
+          {isLoading && <Skeleton width={300} height={300} borderRadius={10} />}
+          <img
+            css={imageStyles(isLoading)}
+            src={album.images[1].url}
+            alt={album.name}
+            onLoad={() => setIsLoading(false)}
+          />
         </div>
       </div>
       <Button onClick={onNext}>투표하기</Button>
@@ -49,8 +58,8 @@ const imageWrapperStyles = css`
   height: 300px;
 `
 
-const imageStyles = css`
-  display: block;
+const imageStyles = (isLoading: boolean) => css`
+  display: ${isLoading ? `none` : `block`};
   width: 100%;
   height: 100%;
   object-fit: contain;

--- a/src/components/form/vote/FormInfo.tsx
+++ b/src/components/form/vote/FormInfo.tsx
@@ -22,7 +22,9 @@ export default function FormInfo({ form, onNext }: FormInfoProps) {
         <Text css={textStyles} variant={'heading2'}>
           {album.name}
         </Text>
-        <img css={imageStyles} src={album.images[1].url} alt={album.name} />
+        <div css={imageWrapperStyles}>
+          <img css={imageStyles} src={album.images[1].url} alt={album.name} />
+        </div>
       </div>
       <Button onClick={onNext}>투표하기</Button>
     </section>
@@ -39,11 +41,19 @@ const sectionStyles = css`
 
 const divStyles = css`
   ${flexColumnCenter}
-  gap: 5px;
+  gap: 25px;
+`
+
+const imageWrapperStyles = css`
+  width: 300px;
+  height: 300px;
 `
 
 const imageStyles = css`
   display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
   border-radius: 10px;
 `
 


### PR DESCRIPTION
## 작업 내용
이미지 로딩까지 시간이 걸리는 부분에 스켈레톤 UI 적용해 사용자 경험 개선
- [x] 스켈레톤 UI 적용
- [x] ImgWrapper로 이미지를 감싸 이미지 로드 시 레이아웃이 무너지는 문제 해결

## 스크린샷
![ezgif-1-9c0bce6575](https://github.com/uussong/go-to-track/assets/77879633/dee14824-2a9f-484e-ba28-fcb83e55c66c)
이 외 이미지를 불러오는 컴포넌트에 모두 적용